### PR TITLE
Fix possible typo in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    django31: Django>=3.2,<3.3
+    django32: Django>=3.2,<3.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
Hi, 

Thanks for this nice code, I believe the following line in `tox.ini` is a typo, and intends to test django 3.2?